### PR TITLE
Navya - Assignment 9  - Add changes to Compile Singleton Assignment

### DIFF
--- a/src/HW9/edu/fsu/csc7400/patterns/singleton/BaseSingleton.java
+++ b/src/HW9/edu/fsu/csc7400/patterns/singleton/BaseSingleton.java
@@ -4,6 +4,8 @@
  * Assignment: HW 9 - Singleton Problems
  * 
  * Date: 2017-11-11
+ * 
+ * @author Navya Inampudi
  */
 package HW9.edu.fsu.csc7400.patterns.singleton;
 
@@ -12,6 +14,7 @@ package HW9.edu.fsu.csc7400.patterns.singleton;
  * and subclassing work
  * 
  * @author orlando
+ * @author ninampudi
  */
 public class BaseSingleton {	
 	/**
@@ -59,7 +62,9 @@ public class BaseSingleton {
 	
 	/**
 	 * Private constructor for singleton
+	 * Changed the access modifier from Private to Protected. So, that BaseSingleton class can be extended.
+	 * Otherwise this constructor will not be visible in the child classes.
 	 */
-	private BaseSingleton() {
+	protected BaseSingleton() {
 	}
 }

--- a/src/HW9/edu/fsu/csc7400/patterns/singleton/SubClassSingleton.java
+++ b/src/HW9/edu/fsu/csc7400/patterns/singleton/SubClassSingleton.java
@@ -2,8 +2,10 @@
  * Class: Object-Oriented Design and Analysis
  * Professor: Orlando Montalvo
  * Assignment: HW 9 - Singleton Problems
- * 
  * Date: 2017-11-11
+ * 
+ * @author Navya Inampudi
+ * 
  */
 package HW9.edu.fsu.csc7400.patterns.singleton;
 
@@ -11,14 +13,18 @@ package HW9.edu.fsu.csc7400.patterns.singleton;
  * Subclassed singleton. Will set the state to different value
  * 
  * @author orlando
+ * @author ninampudi
  */
 public class SubClassSingleton extends BaseSingleton {
 
 	/**
 	 * Simple function that sets state
+	 * 
+	 * When we override the parent method, we shall match the method name, as they are case-sensitive. 
+	 * Hence producing the error. Corrected the same.
 	 */
 	@Override
-	public void DoSomething() {
+	public void doSomething() {
 		setSomeState(2);
 	}
 
@@ -34,7 +40,26 @@ public class SubClassSingleton extends BaseSingleton {
 
 	/**
 	 * Single constructor must be private
+	 * 
+	 * Since the constructors in the singleton is private, the super constructor is not visible. Hence the code will not compile.
+	 * To fix this make the Parent constructor to Protected from Private.
 	 */
-	private SubClassSingleton() {
+	public SubClassSingleton() {
 	}
+	
+	/**
+	 *  Holds singleton instance of type SubClassSingleton
+	 */
+	private static SubClassSingleton instance;
+	
+	/**
+	 * Singleton instance creation. Use the getInstance to create instance for SubClassSingleton
+	 * @return singleton instance
+	 */
+	public static synchronized BaseSingleton getInstance() {
+			if (instance == null)
+				instance = new SubClassSingleton();
+			return instance;
+	}
+	
 }

--- a/test/HW9/edu/fsu/csc7400/patterns/singleton/SubClassSingletonTest.java
+++ b/test/HW9/edu/fsu/csc7400/patterns/singleton/SubClassSingletonTest.java
@@ -9,14 +9,20 @@ import org.junit.jupiter.api.Test;
  * BaseSingletonTest will do a basic test of the base singleton
  * 
  * @author orlando
+ * @author Navya Inampudi
  */
 class SubClassSingletonTest {
 	
 	private SubClassSingleton singleton;
-
+	
+	/**
+	 * 
+	 * This tests the instance creation for the class SubClassSingleton.
+	 * Added the type casting to fix the instance creation from the sub class.
+	 */
 	@BeforeEach
 	void setUp() throws Exception {
-		singleton = SubClassSingleton.getInstance();
+		singleton = (SubClassSingleton) SubClassSingleton.getInstance();
 	}
 
 	@Test


### PR DESCRIPTION
The code would not execute as the child class cannot see the parent constructor. To fix this, made the below changes -
1) BaseSingleton.java - Change  Base Singleton Class Contructor access modifier from Private to Protected.
2) SubClassSingleton.java - Added a getInstance method to create an singleton instance.
3) SubClassSingleton.java - Added Type Casting to support getInstance() creation for SubClassSingleton class.